### PR TITLE
added Chartbuilder startup script

### DIFF
--- a/Chartbuilder.sh
+++ b/Chartbuilder.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -m
+# A small launch script, starts the webserver and then opens a browser
+#
+#
+
+WD=`pwd`
+PYTHON="python2"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+$PYTHON -m SimpleHTTPServer &
+sleep 1;
+if command -v open >/dev/null; then
+  open http://127.0.0.1:8000;
+else
+  xdg-open http://127.0.0.1:8000;
+fi
+
+fg
+
+cd $WD

--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ How to use Chartbuilder
 ------------------------
 ###Getting started
 1. [Download source](https://github.com/Quartz/Chartbuilder/archive/master.zip) (and unzip)
+2. Run the Chartbuilder.sh script in the directory (double-clicking on Mac)
+3. A browser window will open on [http://localhost:8000](http://localhost:8000)
+
+Alternatively 
+
 3. from the terminal navigate to the source folder (on a Mac: `cd ~/Downloads/Chartbuilder-master/`) 
 4. run `python -m SimpleHTTPServer`
 5. Open Google Chrome, Apple Safari, or Opera and navigate to [http://localhost:8000/](http://localhost:8000/)


### PR DESCRIPTION
Added a Chartbuilder startup script - this should enable double clicking in mac to start chartbuilder. (Also works on *nix systems with xdg-open).
