### PR TITLE
Pull request to add a new date format for X axis labeling, used everywhere outside the US.

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
 						</select>
 						<label for="x_axis_date_format">X Axis Date Format</label><select name="x_axis_date_format" id="x_axis_date_format">
 							<option value="mmddyyyy">2/25/2012</option>
+							<option value="ddmmyyyy">25/2/2012</option>
 							<option value="mmdd">2/25</option>
 							<option value="Mdd">Feb. 25</option>
 							<option value="mmyy">2/13</option>

--- a/js/gneisschart.js
+++ b/js/gneisschart.js
@@ -95,7 +95,8 @@ var Gneiss = {
 	longMonths: ["January","February","March","April","May","June","July","August","September","October","November","December"],
 	shortMonths: ["Jan.","Feb.","March","April","May","June","July","Aug.","Sept.","Oct.","Nov.","Dec."],
 	dateParsers: {
-		"mmddyyyy": function(d) {return [d.getMonth()+1,d.getDate(),d.getFullYear()].join("/");},
+		"mmddyyyy": function(d) {return [d.getMonth()+1,d.getDate(),d.getFullYear()].join("/")},
+		"ddmmyyyy": function(d) {return [d.getDate(),d.getMonth()+1,d.getFullYear()].join("/")},
 		"mmdd": function(d) {return [d.getMonth()+1,d.getDate()].join("/")},
 		"Mdd": function(d){
 			return Gneiss.shortMonths[d.getMonth()] +" "+ Number(d.getDate())


### PR DESCRIPTION
Added new date format, continental European usage, see https://en.wikipedia.org/wiki/Calendar_date#Expressing_dates_in_spoken_English

This format is used everywhere outside the US.

Hope this quick fix could be merged.
