### PR TITLE
Fixed bug 6. When the scale collapses with an empty axis min field.

### DIFF
--- a/js/chartbuilder.js
+++ b/js/chartbuilder.js
@@ -525,12 +525,10 @@ ChartBuilder = {
 			ChartBuilder.inlineAllStyles();
 		},
 		axis_min_change: function(index,that) {
-			var val = $(that).val()
-			var val = parseFloat(val)
-			if(val == NaN) {
-				val == null
+			var val = parseFloat($(that).val())
+			if(isNaN(val)) {
+				val = null
 			}
-
 			chart.g.yAxis[index].domain[0] = val;
 			chart.setYScales();
 			ChartBuilder.redraw()


### PR DESCRIPTION
There was a bug that when the min field of the axis was empty the scale would collapse. This commit fixes that.
