### PR TITLE
Switch to getBoundingClientRect() and update Retina detection to fix Firefox

### DIFF
--- a/css/chartbuilder.css
+++ b/css/chartbuilder.css
@@ -189,15 +189,14 @@ select {
 	font-family: 'PTSerif';
 	color: #666666;
 	border: 1px solid #ccc;
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing:border-box;
 	box-sizing: border-box;
-     -webkit-box-sizing:border-box;
-     -moz-box-sizing: border-box;
 }
 
 input[type="text"] {
 	padding: .25em 2%;
 	width: 96%;
-
 }
 
 textarea {
@@ -247,7 +246,6 @@ textarea {
 		width: 46%;
 		padding-right: 2%;
 		padding-left: 2%;
-
 	}
 }
 
@@ -288,7 +286,7 @@ textarea {
 }
 
 #seriesItems .seriesItemGroup input, 
-#seriesItems .seriesItemGroup select,
+#seriesItems .seriesItemGroup select
 {
 	float: left;
 	margin-left: .5em;

--- a/js/chartbuilder.js
+++ b/js/chartbuilder.js
@@ -668,8 +668,13 @@ ChartBuilder.start = function(config) {
   	//this should change to be more like this http://bost.ocks.org/mike/chart/
     chart = new Gneiss(chartConfig);
     
-  	//scale it up so it looks good on retina displays
-  	$("#chart").attr("transform","scale(2)")
+  	// Determine if we need to scale the chart up so it looks good on retina displays
+		var isRetina = (window.devicePixelRatio > 1 ||
+			(window.matchMedia && window.matchMedia("(-webkit-min-device-pixel-ratio: 1.5)," +
+				"(-moz-min-device-pixel-ratio: 1.5),(min-device-pixel-ratio: 1.5)").matches)
+		);
+				
+  	$("#chart").attr("transform", isRetina ? "scale(2)" : "scale(1)");
   	
   	//populate the input with the data that is in the chart
   	$("#csvInput").val(function() {

--- a/js/gneisschart.js
+++ b/js/gneisschart.js
@@ -915,7 +915,7 @@ function Gneiss(config)
 			.attr("text-anchor", g.xAxis.type == "date" ? (g.seriesByType().column.length>0 && g.seriesByType().line.length == 0 && g.seriesByType().scatter.length == 0 ? "middle":"start"): (g.isBargrid() ? "end":"middle"))
 			//.attr("text-anchor", g.isBargrid ? "end":"middle")
 			.each(function() {
-				var pwidth = this.parentNode.getBBox().width
+				var pwidth = this.parentNode.getBoundingClientRect().width
 				var attr = this.parentNode.getAttribute("transform")
 				var attrx = Number(attr.split("(")[1].split(",")[0])
 				var attry = Number(attr.split(")")[0].split(",")[1])
@@ -1391,11 +1391,11 @@ function Gneiss(config)
 					.attr("transform",function(d,i) {
 						//label isn't for the first series
 						var prev = d3.select(legendGroups[0][i]);
-						var prevWidth = parseFloat(prev.node().getBBox().width);
+						var prevWidth = parseFloat(prev.node().getBoundingClientRect().width);
 						var prevCoords = Gneiss.helper.transformCoordOf(prev);
 
 						var cur = d3.select(this);
-						var curWidth = parseFloat(cur.node().getBBox().width);
+						var curWidth = parseFloat(cur.node().getBoundingClientRect().width);
 						var curCoords = Gneiss.helper.transformCoordOf(cur);
 
 						legendItemY = prevCoords.y;


### PR DESCRIPTION
Use getBoundingClientRect() instead of getBBox() to work around [this](https://bugzilla.mozilla.org/show_bug.cgi?id=612118) Firefox SVG bug.

Fix basic CSS issues and update scaling determination since Firefox seems to respect the transform=scale operator and Webkit does not appear to.

Someone needs to test this on a Retina machine to ensure that the scaling is properly applied.
