### PR TITLE
Add missing keys to export buttons to avoid React warning.

### DIFF
--- a/src/js/components/ChartExport.jsx
+++ b/src/js/components/ChartExport.jsx
@@ -279,6 +279,7 @@ var ChartExport = React.createClass({
 
 		var chartExportButtons = [
 			<Button
+				key="png"
 				className="export-button"
 				onClick={this.downloadPNG}
 				text="Download Image"
@@ -287,6 +288,7 @@ var ChartExport = React.createClass({
 		if (this.state.enableSvgExport) {
 			chartExportButtons.push(
 				<Button
+					key="svg"
 					className="export-button"
 					onClick={this.downloadSVG}
 					text="Download SVG"


### PR DESCRIPTION
Each child in an array should have a unique "key" prop. Check the render method of ChartExport. See http://fb.me/react-warning-keys for more information.