### PR TITLE
turn off label dragging if chart not editable (only rendered)

### DIFF
--- a/src/js/components/Chartbuilder.jsx
+++ b/src/js/components/Chartbuilder.jsx
@@ -136,6 +136,7 @@ var Chartbuilder = React.createClass({
 			mobileOverrides = (
 				<MobileComponent
 					chartProps={this.state.chartProps}
+					errors={this.state.errors}
 				/>
 			);
 		} else {

--- a/src/js/components/RendererWrapper.jsx
+++ b/src/js/components/RendererWrapper.jsx
@@ -55,7 +55,9 @@ var RendererWrapper = React.createClass({
 	},
 
 	shouldComponentUpdate: function(nextProps, nextState) {
-		if (!nextProps.model.errors.valid) {
+		if (!nextProps.model.errors) {
+			return true;
+		} else if (!nextProps.model.errors.valid) {
 			return false;
 		}
 		return true;

--- a/src/js/components/chart-xy/XYEditor.jsx
+++ b/src/js/components/chart-xy/XYEditor.jsx
@@ -130,6 +130,7 @@ var XYEditor = React.createClass({
 				<XY_yScaleSettings
 					scale={chartProps.scale}
 					onUpdate={this._handlePropAndReparse.bind(null, "scale")}
+					errors={axisErrors}
 					onReset={this._handlePropAndReparse.bind(null, "scale")}
 					className="scale-options"
 					id="secondaryScale"

--- a/src/js/components/chart-xy/XYMobile.jsx
+++ b/src/js/components/chart-xy/XYMobile.jsx
@@ -44,10 +44,15 @@ var XYMobile = React.createClass({
 		var scaleSettings = [];
 		var scale = chartProps.mobile.scale || chartProps.scale;
 
+		var axisErrors = this.props.errors.messages.filter(function(e) {
+			return e.location === "axis";
+		});
+
 		/* Y scale settings */
 		scaleSettings.push(
 			<XY_yScaleSettings
 				scale={scale}
+				errors={axisErrors}
 				className="scale-options"
 				onUpdate={this._handleScaleUpdate.bind(null, "scale")}
 				onReset={this._handleScaleReset}

--- a/src/js/components/chart-xy/XYRenderer.jsx
+++ b/src/js/components/chart-xy/XYRenderer.jsx
@@ -389,6 +389,7 @@ var XYLabels = React.createClass({
 
 	propTypes: {
 		chartProps: PropTypes.object.isRequired,
+		editable: PropTypes.bool,
 		hasTitle: PropTypes.bool.isRequired,
 		displayConfig: PropTypes.object.isRequired,
 		styleConfig: PropTypes.object.isRequired,
@@ -766,8 +767,8 @@ function drawXY(el, state) {
 						text: numericSettings ? numericSettings.suffix : "",
 						dy: "1.6em"
 					}]
-				})			
-			
+				})
+
 		});
 
 		if (chartProps._numSecondaryAxis > 0) {

--- a/src/js/components/shared/XY_yScaleSettings.jsx
+++ b/src/js/components/shared/XY_yScaleSettings.jsx
@@ -54,10 +54,11 @@ var XY_yScaleSettings = React.createClass({
 
 	_renderErrors: function() {
 
-		if (this.props.errors.length === 0) {
+		if (!this.props.errors) {
+			return null;
+		} else if (this.props.errors.length === 0) {
 			return null;
 		} else {
-
 			var errors = this.props.errors.map(function(error, i) {
 				return (
 					<ErrorMessage

--- a/src/js/components/svg/SvgRectLabel.jsx
+++ b/src/js/components/svg/SvgRectLabel.jsx
@@ -457,6 +457,13 @@ var SvgRectLabel = React.createClass({
 			</g>
 		}
 
+		var handleMouseDown = null;
+		var draggableClass = "";
+		if (this.props.editable) {
+			handleMouseDown = this._onMouseDown;
+			draggableClass = "draggable";
+		}
+
 		return (
 			<g
 				className="svg-label-g"
@@ -464,17 +471,16 @@ var SvgRectLabel = React.createClass({
 			>
 				{rect}
 				<text
-					className={["svg-label-text", colorClass].join(" ")}
+					className={["svg-label-text", colorClass, draggableClass].join(" ")}
 					x={textOffsetX}
 					y={textOffsetY}
 					dy={dy}
 					draggable={this.props.editable}
-					onMouseDown={this._onMouseDown}
+					onMouseDown={handleMouseDown}
 				>
 					{this.props.text}
 				</text>
 				{crosshair}
-
 			</g>
 		);
 	}

--- a/src/styl/chart-renderer.styl
+++ b/src/styl/chart-renderer.styl
@@ -111,14 +111,14 @@ svg
 .svg-text
   font-family $font-sans-light
   font-size $em_size
-  
+
   tspan
     &.em
       font-style italic
-      
+
     &.strong
       font-family $font-sans-bold
-      
+
     &.strong .em, &.em .strong
       font-family $font-sans-bold
       font-style italic
@@ -149,7 +149,8 @@ svg
 .svg-label-text
   font-size $em_size
   font-family $font-sans-light
-  cursor move
+  &.draggable
+    cursor move
 
 .crosshair
   line


### PR DESCRIPTION
Some other stuff related to putting errors in the mobile settings got mixed in here. But it's harmless