### PR TITLE
Allows you to define a timezone of the data and choose how it's displayed

### DIFF
--- a/src/js/charts/cb-chart-grid/chart-grid-config.js
+++ b/src/js/charts/cb-chart-grid/chart-grid-config.js
@@ -85,7 +85,9 @@ var defaultProps = {
 			},
 			dateSettings: {
 				dateFrequency: "auto",
-				dateFormat: "auto"
+				dateFormat: "auto",
+				inputTZ: null,
+				displayTZ: "as-entered"
 			},
 			numericSettings: {
 				ticks: null,

--- a/src/js/charts/cb-chart-grid/parse-chart-grid.js
+++ b/src/js/charts/cb-chart-grid/parse-chart-grid.js
@@ -25,7 +25,11 @@ function parseChartgrid(config, _chartProps, callback, parseOpts) {
 	parseOpts = parseOpts || {};
 	// dont check for date column if grid type is bar
 	var checkForDate = chartProps._grid.type !== "bar";
-	var bySeries = dataBySeries(chartProps.input.raw, { checkForDate: checkForDate, type: chartProps.input.type});
+	var bySeries = dataBySeries(chartProps.input.raw, {
+			checkForDate: checkForDate, 
+			type: chartProps.input.type,
+			inputTZ: chartProps.scale.dateSettings ? chartProps.scale.dateSettings.inputTZ : null
+		});
 
 	var gridSettings = {
 		rows: +chartProps._grid.rows || chartgrid_defaults._grid.rows,

--- a/src/js/charts/cb-xy/parse-xy.js
+++ b/src/js/charts/cb-xy/parse-xy.js
@@ -22,8 +22,11 @@ function parseXY(config, _chartProps, callback, parseOpts) {
 	// clone so that we aren't modifying original
 	// this can probably be avoided by applying new settings differently
 	var chartProps = JSON.parse(JSON.stringify(_chartProps));
-
-	var bySeries = dataBySeries(chartProps.input.raw, { checkForDate: true, type: chartProps.input.type });
+	var bySeries = dataBySeries(chartProps.input.raw, { 
+			checkForDate: true, 
+			type: chartProps.input.type,
+			inputTZ: chartProps.scale.dateSettings ? chartProps.scale.dateSettings.inputTZ : null
+		});
 	var labels = chartProps._annotations.labels;
 	var allColumn = true;
 	// check if either scale contains columns, as we'll need to zero the axis

--- a/src/js/charts/cb-xy/xy-config.js
+++ b/src/js/charts/cb-xy/xy-config.js
@@ -1,4 +1,5 @@
 var ChartConfig = require("../ChartConfig");
+var now = new Date();
 
 /**
  * ### Configuration of an XY chart
@@ -29,6 +30,7 @@ var ChartConfig = require("../ChartConfig");
 * @property {object} margin - Distances btwn outer chart elements and container
 * @property {object} padding - Distances btwn inner chart elements and container
 */
+
 var display = {
 	labelRectSize: "0.6em",
 	labelXMargin: "0.6em",
@@ -92,7 +94,9 @@ var defaultProps = {
 			},
 			dateSettings: {
 				dateFrequency: "auto",
-				dateFormat: "auto"
+				dateFormat: "auto",
+				inputTZ: null,
+				displayTZ: "as-entered"
 			},
 			numericSettings: {
 				ticks: null,

--- a/src/js/components/chart-grid/ChartGridEditor.jsx
+++ b/src/js/components/chart-grid/ChartGridEditor.jsx
@@ -124,7 +124,7 @@ var ChartGridEditor = React.createClass({
 					key="xScale"
 					scale={chartProps.scale}
 					stepNumber="5"
-					onUpdate={this._handlePropUpdate.bind(null, "scale")}
+					onUpdate={this._handlePropAndReparse.bind(null, "scale")}
 				/>
 			)
 		} else if (chartProps.scale.isNumeric) {

--- a/src/js/components/chart-grid/ChartGridXY.jsx
+++ b/src/js/components/chart-grid/ChartGridXY.jsx
@@ -367,8 +367,16 @@ function drawXYChartGrid(el, state) {
 	.using("xAxis", function(axis) {
 		if (chartProps.scale.hasDate) {
 			axis.tickValues(dateSettings.dateTicks);
-			axis.tickFormat(function(d) {
-				return dateSettings.dateFormatter(d);
+			var curOffset = Date.create().getTimezoneOffset();
+			var displayTZ = state.chartProps.scale.dateSettings.displayTZ;
+			var inputOffset = state.chartProps.scale.dateSettings.inputTZ ? -help.TZOffsetToMinutes(state.chartProps.scale.dateSettings.inputTZ) : curOffset;
+			var timeOffset = 0;
+			axis.tickFormat(function(d,i) {
+				if(displayTZ === "as-entered") {
+					timeOffset = curOffset - inputOffset;
+				}
+
+				return dateSettings.dateFormatter(d.clone(),i,timeOffset);
 			});
 		}
 

--- a/src/js/components/chart-xy/XYEditor.jsx
+++ b/src/js/components/chart-xy/XYEditor.jsx
@@ -135,7 +135,7 @@ var XYEditor = React.createClass({
 					key="xScale"
 					scale={chartProps.scale}
 					stepNumber="5"
-					onUpdate={this._handlePropUpdate.bind(null, "scale")}
+					onUpdate={this._handlePropAndReparse.bind(null, "scale")}
 				/>
 			);
 		} else if (chartProps.scale.isNumeric) {

--- a/src/js/components/chart-xy/XYRenderer.jsx
+++ b/src/js/components/chart-xy/XYRenderer.jsx
@@ -743,9 +743,18 @@ function drawXY(el, state) {
 			});
 
 			if (dateSettings) {
+				var curOffset = Date.create().getTimezoneOffset()
 				axis.tickValues(dateSettings.dateTicks);
+				var displayTZ = state.chartProps.scale.dateSettings.displayTZ;
+				var inputOffset = state.chartProps.scale.dateSettings.inputTZ ? -help.TZOffsetToMinutes(state.chartProps.scale.dateSettings.inputTZ) : curOffset;
+				var timeOffset = 0;
 				axis.tickFormat(function(d,i) {
-					return dateSettings.dateFormatter(d,i);
+
+					if(displayTZ === "as-entered") {
+						timeOffset = curOffset - inputOffset;
+					}
+
+					return dateSettings.dateFormatter(d.clone(),i,timeOffset);
 				});
 			}
 

--- a/src/js/util/error-names.js
+++ b/src/js/util/error-names.js
@@ -48,6 +48,11 @@ var error_names = {
 		location: "input",
 		text: "The type of information in the first column of your data cannot be automatically determined. Please seleect one below.",
 		type: 2
+	},
+	"UNEVEN_TZ": {
+		location: "input",
+		text: "Some of your dates are specified with timezones and some of them are not. This may cause erroneous plotting.",
+		type: 2
 	}
 };
 

--- a/src/js/util/helper.js
+++ b/src/js/util/helper.js
@@ -215,29 +215,16 @@ function merge_or_apply(defaults, source) {
 	}, {});
 }
 
+/**
+ * Given a the domain of a scale suggest the most numerous number 
+ * of round number ticks that it cold be divided into while still containing
+ values evenly divisible by 1, 2, 2.5, 5, 10, or 25.
+ * @param {array} domain - An array of two number like objects
+ * @returns {integer} - Result is a single integer representing a nice number of ticks to use
+ * @static
+ * @memberof helper
+*/
 function suggest_tick_num(domain) {
-	// function axis_ticks_even(scale) {
-	// 	var range = (scale.domain[1] - scale.domain[0]);
-	// 	var minimum = range / MAX_TICKS;
-	// 	var digits = Math.floor(range).toString().length;
-	// 	var multiplier = Math.pow(10, (digits - 2));
-
-	// 	var acceptable_intervals = reduce(INTERVAL_BASE_VALS, function(prev, curr) {
-	// 		var mult = curr * multiplier;
-
-	// 		if (mult >= minimum) {
-	// 			prev = prev.concat([mult]);
-	// 		}
-
-	// 		return prev;
-	// 	}, []);
-
-	// 	var are_ticks_even = some(acceptable_intervals, function(inter) {
-	// 		return all_modulo(scale.tickValues, inter);
-	// 	});
-
-	// 	return are_ticks_even;
-	// }
 	var MAX_TICKS = 10;
 	var INTERVAL_BASE_VALS = [1, 2, 2.5, 5, 10, 25];
 	var range = Math.abs(domain[0] - domain[1])
@@ -266,6 +253,34 @@ function suggest_tick_num(domain) {
 }
 
 /**
+ * Given a timezone offset in an hour:minute format and return the equivalent
+ * number of minutes as a number
+ * only exist in the source object.
+ * @param {object} offset - A string in a hh:mm format or "Z" for no offset
+ * @returns {number} - Number of minutes
+ * @static
+ * @memberof helper
+*/
+function tz_offset_to_minutes(offset) {
+	if (offset == "Z") {
+		return 0
+	}
+
+	var offset = offset.split(":")
+
+	if(offset.length == 1) {
+		offset = offset[0]
+		split_loc = offset.length - 2
+		offset = [offset.substring(0, split_loc), offset.substring(split_loc)]
+	}
+	sign = offset[0].indexOf("-") > -1 ? -1 : 1
+
+	offset = offset.map(parseFloat)
+
+	return (offset[0]*60) + (sign * offset[1])
+}
+
+/**
  * Helper functions!
  * @name helper
  */
@@ -277,7 +292,8 @@ var helper = {
 	precision: precision,
 	transformCoords: transform_coords,
 	mergeOrApply: merge_or_apply,
-	suggestTickNum: suggest_tick_num
+	suggestTickNum: suggest_tick_num,
+	TZOffsetToMinutes: tz_offset_to_minutes
 };
 
 module.exports = helper;

--- a/src/js/util/parse-data-by-series.js
+++ b/src/js/util/parse-data-by-series.js
@@ -6,7 +6,7 @@
 // ```
 
 var datePattern = /date|time|year/i;
-var parseDelimInput = require("./parse-delimited-input");
+var parseDelimInput = require("./parse-delimited-input").parser;
 
 // Parse data by series. Options:
 // checkForDate: bool | tell parser to return dates if key column is date/time/year
@@ -16,7 +16,8 @@ function dataBySeries(input, opts) {
 
 	var parsedInput = parseDelimInput(input, {
 		checkForDate: opts.checkForDate,
-		type: opts.type
+		type: opts.type,
+		inputTZ: opts.inputTZ
 	});
 
 	var columnNames = parsedInput.columnNames;

--- a/src/js/util/process-dates.js
+++ b/src/js/util/process-dates.js
@@ -8,15 +8,24 @@ require("sugar-date");
 // Parse dates and return strings based on selected format
 var dateParsers = {
 
-	"lmdy": function(d) {
+	"lmdy": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return d.format('{M}/{d}/{yy}');
 	},
 
-	"mmdd": function(d) {
+	"mmdd": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return d.format('{M}/{d}');
 	},
 
-	"Mdd": function(d) {
+	"Mdd": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var month = d.getMonth() + 1;
 		if (month == 5) {
 			return d.format('{Month} {d}');
@@ -25,7 +34,10 @@ var dateParsers = {
 		}
 	},
 
-	"M1d": function(d,i) {
+	"M1d": function(d,i,o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var date = d.getDate();
 		if(date == 1) {
 			return dateParsers.M(d);
@@ -36,7 +48,10 @@ var dateParsers = {
 		}
 	},
 
-	"ddM": function(d) {
+	"ddM": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var month = d.getMonth() + 1;
 		if (month == 5) {
 			return d.format('{d} {Month}');
@@ -45,19 +60,31 @@ var dateParsers = {
 		}
 	},
 
-	"mmyy": function(d) {
+	"mmyy": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return d.format('{M}/' + dateParsers.yyyy(d).slice(-2));
 	},
 
-	"yy": function(d) {
+	"yy": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return "’" + dateParsers.yyyy(d).slice(-2);
 	},
 
-	"yyyy": function(d) {
+	"yyyy": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return "" + d.getFullYear();
 	},
 
-	"MM": function(d) {
+	"MM": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var month = d.getMonth() + 1;
 		if (month == 1) {
 			return "" + d.getFullYear();
@@ -66,7 +93,10 @@ var dateParsers = {
 		}
 	},
 
-	"M": function(d) {
+	"M": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var month = d.getMonth() + 1;
 		if (month == 1) {
 			return "’" + dateParsers.yyyy(d).slice(-2);
@@ -77,15 +107,24 @@ var dateParsers = {
 		}
 	},
 
-	"hmm": function(d) {
+	"hmm": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return d.format("{h}:{mm}");
 	},
 
-	"h": function(d) {
+	"h": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		return d.format("{h}{tt}");
 	},
 
-	"QJan": function(d) {
+	"QJan": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var year = d.getFullYear();
 		var month = d.getMonth() + 1;
 		var day = d.getDate();
@@ -103,7 +142,10 @@ var dateParsers = {
 		return "";
 	},
 
-	"QJul": function(d) {
+	"QJul": function(d, i, o) {
+		if(o) {
+			d.addMinutes(o)
+		}
 		var year = d.getFullYear();
 		var month = d.getMonth() + 1;
 		var day = d.getDate();

--- a/src/js/util/validate-data-input.js
+++ b/src/js/util/validate-data-input.js
@@ -57,8 +57,10 @@ function validateDataInput(chartProps) {
 	// Whether a column has NaN
 	var nanSeries = dataPointTest(
 			series,
-			function(val) { return isNaN(val.value); },
-			function(nan, vals) { return nan.length > 0;}
+			function(val) {
+				return (isNaN(val.value) && val.value !== undefined && val.value !== "");
+			},
+			function(nan, vals) {return nan.length > 0;}
 		);
 
 	if (nanSeries) {
@@ -95,6 +97,12 @@ function validateDataInput(chartProps) {
 
 		if (badDateSeries) {
 			inputErrors.push("NOT_DATES");
+		}
+
+		var tz_pattern = /([+-]\d\d:*\d\d)/gi;
+		var found_timezones = input.match(tz_pattern);
+		if(found_timezones && found_timezones.length != series[0].values.length) {
+			inputErrors.push("UNEVEN_TZ");
 		}
 	}
 

--- a/test/date-parsers.js
+++ b/test/date-parsers.js
@@ -3,14 +3,19 @@ require("sugar-date"); // sugar is used for date parsing
 
 var processDates = require("../src/js/util/process-dates");
 var dateParsers = processDates.dateParsers;
+var now = new Date();
 var date1 = new Date(1982, 0, 1);
 var date2 = new Date(1998, 4, 15);
 var date3 = new Date(2015, 7, 31);
 var date4 = new Date(2015, 2, 1);
+
+var date5 = new Date.create("2016-02-02T12:00:00" + now.getUTCOffset());
+var date6 = new Date.create("2016-02-02T12:00:00-0500");
+
 var p;
 
 test("date parsers", function(t) {
-	t.plan(28);
+	t.plan(30);
 
 	p = dateParsers["lmdy"];
 	t.equal(p(date1), "1/1/82", "lmdy format");
@@ -57,6 +62,10 @@ test("date parsers", function(t) {
 	t.equal(p(date1), "1982", "MM format");
 	t.equal(p(date2), "May", "MM format");
 	t.equal(p(date3), "August", "MM format");
+
+	p = dateParsers["h"]
+	t.equal(p(date5), "12pm", "h format")
+	t.equal(p(date6, 0, now.getTimezoneOffset() - 300), "12pm", "h format, timezone adjusted")
 
 	t.end();
 });

--- a/test/helper.js
+++ b/test/helper.js
@@ -90,3 +90,17 @@ test("helper: precision of NaN is 0", function(t) {
 	t.equal(p(0 / 0), 0);
 	t.end();
 });
+
+test("helper: convert timezone strings", function(t) {
+	t.plan(8);
+	var p = help.TZOffsetToMinutes
+	t.equal(p("Z"),0,"Z timezone returns offset of 0 mintues")
+	t.equal(p("-00:00"), 0, "+0000 tz offset returns 0 minutes")
+	t.equal(p("+00:00"), 0, "+0000 tz offset returns 0 minutes")
+	t.equal(p("-08:00"), -480, "-0800 tz offset returns -480 minutes")
+	t.equal(p("+05:00"), 300, "+0500 tz offset returns 600 minutes")
+	t.equal(p("+04:30"), 270, "+0430 tz offset returns 270 minutes")
+	t.equal(p("-04:30"), -270, "-0430 tz offset returns -270 minutes")
+	t.equal(p("+10:00"), 600, "+1030 tz offset returns 600 minutes")
+	t.end();
+})

--- a/test/index.js
+++ b/test/index.js
@@ -4,5 +4,6 @@ require("./helper");
 require("./parse-input");
 require("./date-parsers");
 require("./date-frequencies");
+require("./timezone-adjustments");
 require("./auto-date-interval");
 require("./validate-input");

--- a/test/timezone-adjustments.js
+++ b/test/timezone-adjustments.js
@@ -1,0 +1,93 @@
+var test = require("tape");
+
+var testInput = require("./util/test-input");
+require("sugar-date");
+
+
+var parseDelimitedInput = require("../src/js/util/parse-delimited-input.js");
+var parseUtils = require("../src/js/util/parse-utils.js");
+var cast = parseDelimitedInput._cast_data;
+
+var separators = {
+	decimal: ".",
+	thousands: ","
+};
+
+var stripChars = [
+	"$",
+	"£",
+	"€",
+	"%"
+];
+
+var _stripCharsStr = stripChars.concat([separators.thousands]).reduce(function(a, b) {
+	return a.concat(parseUtils.escapeRegExp(b));
+}, []).join("|");
+var stripCharsRegex = new RegExp(_stripCharsStr, "g");
+
+test("timezone: tz adjustments", function(t) {
+	t.plan(3);
+
+
+	var input = [
+		"date-col	val",
+		"2016-02-02T12:00:00-0800	1",
+		"2016-02-02T12:00:01-0800	1",
+		"2016-02-02T12:00:02-0800	1",
+		"2016-02-02T12:00:03-0800	1"
+	].join("\n");
+
+	var opts = {
+		"inputTZ": "Z"
+	}
+
+	var entries = cast(input, "date", ["date-col", "val"], stripCharsRegex, parseUtils.detectDelimiter(input), opts).entries
+	var expected = [
+		Date.create("2016-02-02T12:00:00-0800"),
+		Date.create("2016-02-02T12:00:01-0800"),
+		Date.create("2016-02-02T12:00:02-0800"),
+		Date.create("2016-02-02T12:00:03-0800")
+	];
+
+	t.deepEqual(entries,expected,"dates that already have a timezone are left alone");
+
+
+	input = [
+		"date-col	val",
+		"Feb. 2 2016 12:00:00	1",
+		"Feb. 2 2016 12:00:01	1",
+		"Feb. 2 2016 12:00:02	1",
+		"Feb. 2 2016 12:00:03	1"
+	].join("\n");
+
+	opts.inputTZ = null;
+
+	expected = [
+		Date.create("2016-02-02T12:00:00"),
+		Date.create("2016-02-02T12:00:01"),
+		Date.create("2016-02-02T12:00:02"),
+		Date.create("2016-02-02T12:00:03")
+	];
+
+	entries = cast(input, "date", ["date-col", "val"], stripCharsRegex, parseUtils.detectDelimiter(input), opts).entries;
+	t.deepEqual(entries, expected,"dates that don't have a timezone are adjusted to local when there is no inputTZ");
+
+
+
+	opts.inputTZ = "-0500";
+
+	expected = [
+		Date.create("2016-02-02T12:00:00-0500"),
+		Date.create("2016-02-02T12:00:01-0500"),
+		Date.create("2016-02-02T12:00:02-0500"),
+		Date.create("2016-02-02T12:00:03-0500")
+	];
+
+	entries = cast(input, "date", ["date-col", "val"], stripCharsRegex, parseUtils.detectDelimiter(input), opts).entries
+
+	t.deepEqual(entries, expected,"dates that don't have a timezone are adjusted to the inputTZ");
+
+
+
+	t.end();
+})


### PR DESCRIPTION
This is a feature that is only really relevant if you're drawing your charts on the fly like we are at Quartz.

It allows the chart creator to specify the timezone of time series data if it is not otherwise contained in the input and also specify if a person viewing the chart should see the timestamps as if that person is in the timezone of the data or if that person is in their own timezone.

For instance, a chart creator can decide that stock market data should always be shown with timestamps on New York time. A chart creator could also also decide that twitter trend data should be shown in the timezone of the person looking at the chart: something that spiked at 12pm in New York will display as spiking at 9am if viewed in Los Angeles.