### PR TITLE
fix bug where bar grids were parsed as dates

### DIFF
--- a/src/js/util/parse-delimited-input.js
+++ b/src/js/util/parse-delimited-input.js
@@ -40,6 +40,10 @@ function parseDelimInput(input, opts) {
 		inputTZ: "Z"
 	});
 
+	if (opts.checkForDate === false) {
+		_defaultOpts.type = "ordinal";
+	}
+
 	parseErrors = [];
 	// create regex of special characters we want to strip out as well as our
 	// computed locale-specific thousands separator.
@@ -64,7 +68,7 @@ function parseDelimInput(input, opts) {
 		hasDate = _defaultOpts.type ? _defaultOpts.type == "date" : index_types[0] === "date";
 		isNumeric = _defaultOpts.type ? _defaultOpts.type == "numeric" : index_types[0] === "number";
 
-		if(isNumeric && !_defaultOpts.type) {
+		if(isNumeric && !_defaultOpts.type && _defaultOpts.checkForDate) {
 			// if the entries are certain four digit numbers that look like years reparse as years if there isn't a specified type
 			var entry_extent = d3.extent(all_entry_values);
 			if(entry_extent[0] > 1500 && entry_extent[1] < 3000) {


### PR DESCRIPTION
there is a currently a bug in the auto-type detection whereby a bar grid with date-like is being parsed as a date and failing, because it is trying to render a javascript `Date` as the tick label. This change sets the type to `ordinal` in the parser if the option `checkForDate` is set to false, but we should probably rename that later on