### PR TITLE
Fix phone image overflow

### DIFF
--- a/src/styl/layout.styl
+++ b/src/styl/layout.styl
@@ -103,7 +103,7 @@ canvas
 
 .clearfix
 	clear both
-	
+
 *
 	-ms-overflow-style none
 
@@ -160,6 +160,7 @@ canvas
 
 		.phone-wrap
 			background-image url('/assets/iphone-6.svg')
+			background-size contain
 			transform scale(1)
 			transform-origin top
 			height 881px
@@ -182,7 +183,7 @@ canvas
 	padding 0 10px
 	min-width 100px
 	@import 'chart-editor.styl'
-	
+
 @media screen and (max-width: $single_column_breakpoint)
 	.header
 		position relative
@@ -204,4 +205,3 @@ canvas
 		margin-left 0
 		display block
 		width 100%
-


### PR DESCRIPTION
Without a `background-size`, `div.phone-wrap` overflows on the right

**Before:**

![](https://d3vv6lp55qjaqc.cloudfront.net/items/3Z3f1z1R2p3p1R2P2j43/Screen%20Shot%202017-02-08%20at%206.20.51%20PM.png?X-CloudApp-Visitor-Id=2e07f853912b0825ac7bb4fd618fe2ff&v=dd667526)

**After:**

![](https://d3vv6lp55qjaqc.cloudfront.net/items/1c3o3C3r0H21062V1K0A/Screen%20Shot%202017-02-08%20at%206.22.46%20PM.png?X-CloudApp-Visitor-Id=2e07f853912b0825ac7bb4fd618fe2ff&v=b8df5c37)