### PR TITLE
Remove react shallow compare

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "markdown-it": "^6.0.0",
     "react": "^15.5.4",
     "react-addons-pure-render-mixin": "^15.5.4",
-    "react-addons-shallow-compare": "^15.5.4",
     "react-addons-update": "^15.5.4",
     "react-dom": "^15.5.4",
     "save-svg-as-png": "git://github.com/nsonnad/saveSvgAsPng.git#clean-svg-fonts",

--- a/src/js/components/shared/DateScaleSettings.jsx
+++ b/src/js/components/shared/DateScaleSettings.jsx
@@ -2,7 +2,6 @@ var React = require("react");
 var clone = require("lodash/clone");
 var map = require("lodash/map");
 
-var shallowEqual = require('react-addons-shallow-compare');
 var PureRenderMixin = require("react-addons-pure-render-mixin");
 var PropTypes = React.PropTypes;
 var update = require("react-addons-update");


### PR DESCRIPTION
It was no longer used, and also incompatible with React 15.